### PR TITLE
Gpu compatibility v2

### DIFF
--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 [features]
 xen = ["vm-memory/xen", "vhost/xen"]
 postcopy = ["vhost/postcopy", "userfaultfd"]
+gpu-set-socket = ["vhost/vhost-user-gpu-set-socket"]
 
 [dependencies]
 libc = "0.2.39"

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -21,6 +21,7 @@
 use std::fs::File;
 use std::io::Result;
 use std::ops::Deref;
+use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, RwLock};
 
 use vhost::vhost_user::message::{
@@ -83,6 +84,8 @@ pub trait VhostUserBackend: Send + Sync {
     /// A default implementation is provided as we cannot expect all backends to implement this
     /// function.
     fn set_backend_req_fd(&self, _backend: Backend) {}
+
+    fn set_gpu_socket(&self, _stream: UnixStream) {}
 
     /// Get the map to map queue index to worker thread index.
     ///
@@ -194,6 +197,8 @@ pub trait VhostUserBackendMut: Send + Sync {
     /// function.
     fn set_backend_req_fd(&mut self, _backend: Backend) {}
 
+    fn set_gpu_socket(&mut self, _stream: UnixStream) {}
+
     /// Get the map to map queue index to worker thread index.
     ///
     /// A return value of [2, 2, 4] means: the first two queues will be handled by worker thread 0,
@@ -297,6 +302,10 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
 
     fn set_backend_req_fd(&self, backend: Backend) {
         self.deref().set_backend_req_fd(backend)
+    }
+
+    fn set_gpu_socket(&self, stream: UnixStream) {
+        self.deref().set_gpu_socket(stream)
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {
@@ -454,6 +463,10 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
 
     fn set_backend_req_fd(&self, backend: Backend) {
         self.write().unwrap().set_backend_req_fd(backend)
+    }
+
+    fn set_gpu_socket(&self, stream: UnixStream) {
+        self.write().unwrap().set_gpu_socket(stream)
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -9,6 +9,7 @@ use std::io;
 #[cfg(feature = "postcopy")]
 use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::thread;
 
@@ -542,6 +543,10 @@ where
         }
 
         self.backend.set_backend_req_fd(backend);
+    }
+
+    fn set_gpu_socket(&mut self, stream: UnixStream) {
+        self.backend.set_gpu_socket(stream)
     }
 
     fn get_inflight_fd(

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -23,6 +23,7 @@ vhost-net = ["vhost-kern"]
 vhost-user = []
 vhost-user-frontend = ["vhost-user"]
 vhost-user-backend = ["vhost-user"]
+vhost-user-gpu-set-socket = ["vhost-user", "vhost-user-backend"]
 xen = ["vm-memory/xen"]
 postcopy = []
 

--- a/vhost/src/vhost_user/backend.rs
+++ b/vhost/src/vhost_user/backend.rs
@@ -3,6 +3,7 @@
 
 //! Traits and Structs for vhost-user backend.
 
+use crate::vhost_user::header::VhostUserMsgHeader;
 use std::sync::Arc;
 
 use super::connection::{Endpoint, Listener};
@@ -32,7 +33,7 @@ impl<S: VhostUserBackendReqHandler> BackendListener<S> {
     pub fn accept(&mut self) -> Result<Option<BackendReqHandler<S>>> {
         if let Some(fd) = self.listener.accept()? {
             return Ok(Some(BackendReqHandler::new(
-                Endpoint::<FrontendReq>::from_stream(fd),
+                Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(fd),
                 self.backend.take().unwrap(),
             )));
         }

--- a/vhost/src/vhost_user/backend_req.rs
+++ b/vhost/src/vhost_user/backend_req.rs
@@ -15,7 +15,7 @@ use crate::vhost_user::header::VhostUserMsgHeader;
 use vm_memory::ByteValued;
 
 struct BackendInternal {
-    sock: Endpoint<BackendReq>,
+    sock: Endpoint<VhostUserMsgHeader<BackendReq>>,
 
     // Protocol feature VHOST_USER_PROTOCOL_F_REPLY_ACK has been negotiated.
     reply_ack_negotiated: bool,
@@ -84,7 +84,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    fn new(ep: Endpoint<BackendReq>) -> Self {
+    fn new(ep: Endpoint<VhostUserMsgHeader<BackendReq>>) -> Self {
         Backend {
             node: Arc::new(Mutex::new(BackendInternal {
                 sock: ep,
@@ -111,7 +111,9 @@ impl Backend {
 
     /// Create a new instance from a `UnixStream` object.
     pub fn from_stream(sock: UnixStream) -> Self {
-        Self::new(Endpoint::<BackendReq>::from_stream(sock))
+        Self::new(Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(
+            sock,
+        ))
     }
 
     /// Set the negotiation state of the `VHOST_USER_PROTOCOL_F_REPLY_ACK` protocol feature.
@@ -176,7 +178,7 @@ mod tests {
     fn test_backend_req_recv_negative() {
         let (p1, p2) = UnixStream::pair().unwrap();
         let backend = Backend::from_stream(p1);
-        let mut frontend = Endpoint::<BackendReq>::from_stream(p2);
+        let mut frontend = Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(p2);
 
         let len = mem::size_of::<VhostUserFSBackendMsg>();
         let mut hdr = VhostUserMsgHeader::new(

--- a/vhost/src/vhost_user/backend_req.rs
+++ b/vhost/src/vhost_user/backend_req.rs
@@ -11,6 +11,7 @@ use super::connection::Endpoint;
 use super::message::*;
 use super::{Error, HandlerResult, Result, VhostUserFrontendReqHandler};
 
+use crate::vhost_user::header::VhostUserMsgHeader;
 use vm_memory::ByteValued;
 
 struct BackendInternal {

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -9,6 +9,7 @@ use std::os::unix::net::UnixStream;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use crate::vhost_user::header::VhostUserMsgHeader;
 use vm_memory::ByteValued;
 
 use super::backend_req::Backend;

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -548,6 +548,11 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
                 let msg = self.extract_request_body::<VhostUserInflight>(&hdr, size, &buf)?;
                 let res = self.backend.set_inflight_fd(&msg, file);
                 self.send_ack_message(&hdr, res)?;
+            },
+            Ok(FrontendReq::GPU_SET_SOCKET) => {
+                println!("TODO: Got GPU_SET_SOCKET: {files:?}, leaking the handle");
+                mem::forget(files.unwrap().swap_remove(0));
+                self.send_ack_message(&hdr, Ok(()))?;
             }
             Ok(FrontendReq::GET_MAX_MEM_SLOTS) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS)?;
@@ -842,7 +847,8 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
                 | FrontendReq::SET_BACKEND_REQ_FD
                 | FrontendReq::SET_INFLIGHT_FD
                 | FrontendReq::ADD_MEM_REG
-                | FrontendReq::SET_DEVICE_STATE_FD,
+                | FrontendReq::SET_DEVICE_STATE_FD
+                | FrontendReq::GPU_SET_SOCKET
             ) => Ok(()),
             _ if files.is_some() => Err(Error::InvalidMessage),
             _ => Ok(()),

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -305,7 +305,7 @@ impl<T: VhostUserBackendReqHandlerMut> VhostUserBackendReqHandler for Mutex<T> {
 /// [BackendReqHandler]: struct.BackendReqHandler.html
 pub struct BackendReqHandler<S: VhostUserBackendReqHandler> {
     // underlying Unix domain socket for communication
-    main_sock: Endpoint<FrontendReq>,
+    main_sock: Endpoint<VhostUserMsgHeader<FrontendReq>>,
     // the vhost-user backend device object
     backend: Arc<S>,
 
@@ -322,7 +322,10 @@ pub struct BackendReqHandler<S: VhostUserBackendReqHandler> {
 
 impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
     /// Create a vhost-user backend endpoint.
-    pub(super) fn new(main_sock: Endpoint<FrontendReq>, backend: Arc<S>) -> Self {
+    pub(super) fn new(
+        main_sock: Endpoint<VhostUserMsgHeader<FrontendReq>>,
+        backend: Arc<S>,
+    ) -> Self {
         BackendReqHandler {
             main_sock,
             backend,
@@ -362,7 +365,10 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
     /// * - `path` - path of Unix domain socket listener to connect to
     /// * - `backend` - handler for requests from the frontend to the backend
     pub fn connect(path: &str, backend: Arc<S>) -> Result<Self> {
-        Ok(Self::new(Endpoint::<FrontendReq>::connect(path)?, backend))
+        Ok(Self::new(
+            Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(path)?,
+            backend,
+        ))
     }
 
     /// Mark endpoint as failed with specified error code.
@@ -966,7 +972,7 @@ mod tests {
     #[test]
     fn test_backend_req_handler_new() {
         let (p1, _p2) = UnixStream::pair().unwrap();
-        let endpoint = Endpoint::<FrontendReq>::from_stream(p1);
+        let endpoint = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(p1);
         let backend = Arc::new(Mutex::new(DummyBackendReqHandler::new()));
         let mut handler = BackendReqHandler::new(endpoint, backend);
 

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -13,6 +13,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::{mem, slice};
 
+use crate::vhost_user::header::VhostUserMsgHeader;
 use libc::{c_void, iovec};
 use vm_memory::ByteValued;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -13,11 +13,11 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::{mem, slice};
 
-use crate::vhost_user::header::VhostUserMsgHeader;
 use libc::{c_void, iovec};
 use vm_memory::ByteValued;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
+use super::header::MsgHeader;
 use super::message::*;
 use super::{Error, Result};
 
@@ -103,12 +103,12 @@ impl Drop for Listener {
 }
 
 /// Unix domain socket endpoint for vhost-user connection.
-pub(super) struct Endpoint<R: Req> {
+pub(super) struct Endpoint<H: MsgHeader> {
     sock: UnixStream,
-    _r: PhantomData<R>,
+    _h: PhantomData<H>,
 }
 
-impl<R: Req> Endpoint<R> {
+impl<H: MsgHeader> Endpoint<H> {
     /// Create a new stream by connecting to server at `str`.
     ///
     /// # Return:
@@ -123,7 +123,7 @@ impl<R: Req> Endpoint<R> {
     pub fn from_stream(sock: UnixStream) -> Self {
         Endpoint {
             sock,
-            _r: PhantomData,
+            _h: PhantomData,
         }
     }
 
@@ -197,20 +197,16 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketBroken: the underline socket is broken.
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
-    pub fn send_header(
-        &mut self,
-        hdr: &VhostUserMsgHeader<R>,
-        fds: Option<&[RawFd]>,
-    ) -> Result<()> {
+    pub fn send_header(&mut self, hdr: &H, fds: Option<&[RawFd]>) -> Result<()> {
         // SAFETY: Safe because there can't be other mutable referance to hdr.
         let iovs = unsafe {
             [slice::from_raw_parts(
-                hdr as *const VhostUserMsgHeader<R> as *const u8,
-                mem::size_of::<VhostUserMsgHeader<R>>(),
+                hdr as *const H as *const u8,
+                mem::size_of::<H>(),
             )]
         };
         let bytes = self.send_iovec_all(&iovs[..], fds)?;
-        if bytes != mem::size_of::<VhostUserMsgHeader<R>>() {
+        if bytes != mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         }
         Ok(())
@@ -227,7 +223,7 @@ impl<R: Req> Endpoint<R> {
     /// * - PartialMessage: received a partial message.
     pub fn send_message<T: ByteValued>(
         &mut self,
-        hdr: &VhostUserMsgHeader<R>,
+        hdr: &H,
         body: &T,
         fds: Option<&[RawFd]>,
     ) -> Result<()> {
@@ -235,7 +231,7 @@ impl<R: Req> Endpoint<R> {
             return Err(Error::OversizedMsg);
         }
         let bytes = self.send_iovec_all(&[hdr.as_slice(), body.as_slice()], fds)?;
-        if bytes != mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>() {
+        if bytes != mem::size_of::<H>() + mem::size_of::<T>() {
             return Err(Error::PartialMessage);
         }
         Ok(())
@@ -254,7 +250,7 @@ impl<R: Req> Endpoint<R> {
     /// * - IncorrectFds: wrong number of attached fds.
     pub fn send_message_with_payload<T: ByteValued>(
         &mut self,
-        hdr: &VhostUserMsgHeader<R>,
+        hdr: &H,
         body: &T,
         payload: &[u8],
         fds: Option<&[RawFd]>,
@@ -272,7 +268,7 @@ impl<R: Req> Endpoint<R> {
             }
         }
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>() + len;
+        let total = mem::size_of::<H>() + mem::size_of::<T>() + len;
         let len = self.send_iovec_all(&[hdr.as_slice(), body.as_slice(), payload], fds)?;
         if len != total {
             return Err(Error::PartialMessage);
@@ -446,18 +442,18 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
-    pub fn recv_header(&mut self) -> Result<(VhostUserMsgHeader<R>, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    pub fn recv_header(&mut self) -> Result<(H, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut iovs = [iovec {
-            iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-            iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+            iov_base: (&mut hdr as *mut H) as *mut c_void,
+            iov_len: mem::size_of::<H>(),
         }];
         // SAFETY: Safe because we own hdr and it's ByteValued.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
         if bytes == 0 {
             return Err(Error::Disconnected);
-        } else if bytes != mem::size_of::<VhostUserMsgHeader<R>>() {
+        } else if bytes != mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() {
             return Err(Error::InvalidMessage);
@@ -479,13 +475,13 @@ impl<R: Req> Endpoint<R> {
     /// * - InvalidMessage: received a invalid message.
     pub fn recv_body<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
-    ) -> Result<(VhostUserMsgHeader<R>, T, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    ) -> Result<(H, T, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut body: T = Default::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: (&mut body as *mut T) as *mut c_void,
@@ -495,7 +491,7 @@ impl<R: Req> Endpoint<R> {
         // SAFETY: Safe because we own hdr and body and they're ByteValued.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>();
+        let total = mem::size_of::<H>() + mem::size_of::<T>();
         if bytes != total {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() || !body.is_valid() {
@@ -519,15 +515,12 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
-    pub fn recv_body_into_buf(
-        &mut self,
-        buf: &mut [u8],
-    ) -> Result<(VhostUserMsgHeader<R>, usize, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    pub fn recv_body_into_buf(&mut self, buf: &mut [u8]) -> Result<(H, usize, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: buf.as_mut_ptr() as *mut c_void,
@@ -538,13 +531,13 @@ impl<R: Req> Endpoint<R> {
         // and it's safe to fill a byte slice with arbitrary data.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        if bytes < mem::size_of::<VhostUserMsgHeader<R>>() {
+        if bytes < mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() {
             return Err(Error::InvalidMessage);
         }
 
-        Ok((hdr, bytes - mem::size_of::<VhostUserMsgHeader<R>>(), files))
+        Ok((hdr, bytes - mem::size_of::<H>(), files))
     }
 
     /// Receive a message with optional payload and attached file descriptors.
@@ -562,13 +555,13 @@ impl<R: Req> Endpoint<R> {
     pub fn recv_payload_into_buf<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         buf: &mut [u8],
-    ) -> Result<(VhostUserMsgHeader<R>, T, usize, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    ) -> Result<(H, T, usize, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut body: T = Default::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: (&mut body as *mut T) as *mut c_void,
@@ -584,7 +577,7 @@ impl<R: Req> Endpoint<R> {
         // arbitrary data.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>();
+        let total = mem::size_of::<H>() + mem::size_of::<T>();
         if bytes < total {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() || !body.is_valid() {
@@ -595,7 +588,7 @@ impl<R: Req> Endpoint<R> {
     }
 }
 
-impl<T: Req> AsRawFd for Endpoint<T> {
+impl<H: MsgHeader> AsRawFd for Endpoint<H> {
     fn as_raw_fd(&self) -> RawFd {
         self.sock.as_raw_fd()
     }
@@ -623,6 +616,7 @@ fn get_sub_iovs_offset(iov_lens: &[usize], skip_size: usize) -> (usize, usize) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::header::VhostUserMsgHeader;
     use super::*;
     use std::io::{Read, Seek, SeekFrom, Write};
     use vmm_sys_util::rand::rand_alphanumerics;
@@ -670,9 +664,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let buf1 = [0x1, 0x2, 0x3, 0x4];
         let mut len = frontend.send_slice(&buf1[..], None).unwrap();
@@ -696,9 +690,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let mut fd = TempFile::new().unwrap().into_file();
         write!(fd, "test").unwrap();
@@ -847,9 +841,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let mut hdr1 =
             VhostUserMsgHeader::new(FrontendReq::GET_FEATURES, 0, mem::size_of::<u64>() as u32);
@@ -884,7 +878,7 @@ mod tests {
         let listener = Listener::new(&path, true).unwrap();
         let mut frontend = UnixStream::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         write!(frontend, "a").unwrap();
         drop(frontend);
@@ -897,7 +891,7 @@ mod tests {
         let listener = Listener::new(&path, true).unwrap();
         let _ = UnixStream::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         assert!(matches!(backend.recv_header(), Err(Error::Disconnected)));
     }

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -19,6 +19,7 @@ use super::{take_single_file, Error as VhostUserError, Result as VhostUserResult
 use crate::backend::{
     VhostBackend, VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo, VringConfigData,
 };
+use crate::vhost_user::header::VhostUserMsgHeader;
 use crate::{Error, Result};
 
 /// Trait for vhost-user frontend to provide extra methods not covered by the VhostBackend yet.

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -107,7 +107,7 @@ pub struct Frontend {
 
 impl Frontend {
     /// Create a new instance.
-    fn new(ep: Endpoint<FrontendReq>, max_queue_num: u64) -> Self {
+    fn new(ep: Endpoint<VhostUserMsgHeader<FrontendReq>>, max_queue_num: u64) -> Self {
         Frontend {
             node: Arc::new(Mutex::new(FrontendInternal {
                 main_sock: ep,
@@ -129,7 +129,10 @@ impl Frontend {
 
     /// Create a new instance from a Unix stream socket.
     pub fn from_stream(sock: UnixStream, max_queue_num: u64) -> Self {
-        Self::new(Endpoint::<FrontendReq>::from_stream(sock), max_queue_num)
+        Self::new(
+            Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock),
+            max_queue_num,
+        )
     }
 
     /// Create a new vhost-user frontend endpoint.
@@ -141,7 +144,7 @@ impl Frontend {
     pub fn connect<P: AsRef<Path>>(path: P, max_queue_num: u64) -> Result<Self> {
         let mut retry_count = 5;
         let endpoint = loop {
-            match Endpoint::<FrontendReq>::connect(&path) {
+            match Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path) {
                 Ok(endpoint) => break Ok(endpoint),
                 Err(e) => match &e {
                     VhostUserError::SocketConnect(why) => {
@@ -601,7 +604,7 @@ impl VhostUserMemoryContext {
 
 struct FrontendInternal {
     // Used to send requests to the backend.
-    main_sock: Endpoint<FrontendReq>,
+    main_sock: Endpoint<VhostUserMsgHeader<FrontendReq>>,
     // Cached virtio features from the backend.
     virtio_features: u64,
     // Cached acked virtio features from the driver.
@@ -819,7 +822,9 @@ mod tests {
         ))
     }
 
-    fn create_pair<P: AsRef<Path>>(path: P) -> (Frontend, Endpoint<FrontendReq>) {
+    fn create_pair<P: AsRef<Path>>(
+        path: P,
+    ) -> (Frontend, Endpoint<VhostUserMsgHeader<FrontendReq>>) {
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
         let frontend = Frontend::connect(path, 2).unwrap();
@@ -834,7 +839,9 @@ mod tests {
         listener.set_nonblocking(true).unwrap();
 
         let frontend = Frontend::connect(&path, 1).unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(listener.accept().unwrap().unwrap());
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(
+            listener.accept().unwrap().unwrap(),
+        );
 
         assert!(frontend.as_raw_fd() > 0);
         // Send two messages continuously
@@ -1002,7 +1009,7 @@ mod tests {
             .unwrap_err();
     }
 
-    fn create_pair2() -> (Frontend, Endpoint<FrontendReq>) {
+    fn create_pair2() -> (Frontend, Endpoint<VhostUserMsgHeader<FrontendReq>>) {
         let path = temp_path();
         let (frontend, peer) = create_pair(path);
 

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2019-2021 Alibaba Cloud. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::vhost_user::header::VhostUserMsgHeader;
 use std::fs::File;
 use std::mem;
 use std::os::unix::io::{AsRawFd, RawFd};

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -131,7 +131,7 @@ impl<S: VhostUserFrontendReqHandlerMut> VhostUserFrontendReqHandler for Mutex<S>
 /// [VhostUserFrontendReqHandler]: trait.VhostUserFrontendReqHandler.html
 pub struct FrontendReqHandler<S: VhostUserFrontendReqHandler> {
     // underlying Unix domain socket for communication
-    sub_sock: Endpoint<BackendReq>,
+    sub_sock: Endpoint<VhostUserMsgHeader<BackendReq>>,
     tx_sock: UnixStream,
     // Protocol feature VHOST_USER_PROTOCOL_F_REPLY_ACK has been negotiated.
     reply_ack_negotiated: bool,
@@ -154,7 +154,7 @@ impl<S: VhostUserFrontendReqHandler> FrontendReqHandler<S> {
         let (tx, rx) = UnixStream::pair().map_err(Error::SocketError)?;
 
         Ok(FrontendReqHandler {
-            sub_sock: Endpoint::<BackendReq>::from_stream(rx),
+            sub_sock: Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(rx),
             tx_sock: tx,
             reply_ack_negotiated: false,
             backend,

--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -1,0 +1,94 @@
+use std::{io, mem};
+use std::os::fd::RawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex, MutexGuard};
+use vm_memory::ByteValued;
+use crate::vhost_user;
+use crate::vhost_user::connection::Endpoint;
+use crate::vhost_user::Error;
+use crate::vhost_user::gpu_message::{GpuBackendReq, VhostUserGpuMsgHeader};
+use crate::vhost_user::header::VhostUserMsgHeader;
+use crate::vhost_user::message::{BackendReq, VhostUserMsgValidator, VhostUserU64};
+
+struct BackendInternal {
+    sock: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>,
+    // whether the endpoint has encountered any failure
+    error: Option<i32>,
+}
+
+impl BackendInternal {
+    fn check_state(&self) -> vhost_user::Result<u64> {
+        match self.error {
+            Some(e) => Err(Error::SocketBroken(io::Error::from_raw_os_error(e))),
+            None => Ok(0),
+        }
+    }
+
+    fn send_message<T: ByteValued, V: ByteValued + Sized + Default + VhostUserMsgValidator>(
+        &mut self,
+        request: GpuBackendReq,
+        body: &T,
+        fds: Option<&[RawFd]>,
+    ) -> vhost_user::Result<V> {
+        self.check_state()?;
+
+        let len = mem::size_of::<T>();
+        let hdr = VhostUserGpuMsgHeader::new(request, 0, len as u32);
+        self.sock.send_message(&hdr, body, fds)?;
+
+        self.wait_for_ack(&hdr)
+    }
+
+    fn wait_for_ack<V: ByteValued + Sized  + Default + VhostUserMsgValidator>(&mut self, hdr: &VhostUserGpuMsgHeader<GpuBackendReq>) -> vhost_user::Result<V> {
+        self.check_state()?;
+        let (reply, body, rfds) = self.sock.recv_body::<V>()?;
+        if !reply.is_reply_for(hdr) || rfds.is_some() || !body.is_valid() {
+            return Err(Error::InvalidMessage);
+        }
+        Ok(body)
+    }
+}
+
+#[derive(Clone)]
+pub struct GpuBackend {
+    // underlying Unix domain socket for communication
+    node: Arc<Mutex<BackendInternal>>,
+}
+
+impl GpuBackend {
+    fn new(ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>> ) -> Self {
+        Self {
+            node: Arc::new(Mutex::new(BackendInternal {
+                sock: ep,
+                error: None,
+            })),
+        }
+    }
+
+    fn node(&self) -> MutexGuard<BackendInternal> {
+        self.node.lock().unwrap()
+    }
+
+    fn send_message<T: ByteValued, V: ByteValued + Sized + Default + VhostUserMsgValidator>(
+        &self,
+        request: GpuBackendReq,
+        body: &T,
+        fds: Option<&[RawFd]>,
+    ) -> io::Result<V> {
+        self.node()
+            .send_message(request, body, fds)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", e)))
+    }
+
+    /// Create a new instance from a `UnixStream` object.
+    pub fn from_stream(sock: UnixStream) -> Self {
+        Self::new(Endpoint::<VhostUserGpuMsgHeader<GpuBackendReq>>::from_stream(
+            sock,
+        ))
+    }
+
+    /// Mark endpoint as failed with specified error code.
+    pub fn set_failed(&self, error: i32) {
+        self.node().error = Some(error);
+    }
+}

--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -1,14 +1,14 @@
-use std::{io, mem};
-use std::os::fd::RawFd;
-use std::os::unix::net::UnixStream;
-use std::sync::{Arc, Mutex, MutexGuard};
-use vm_memory::ByteValued;
 use crate::vhost_user;
 use crate::vhost_user::connection::Endpoint;
-use crate::vhost_user::Error;
 use crate::vhost_user::gpu_message::{GpuBackendReq, VhostUserGpuMsgHeader};
 use crate::vhost_user::header::VhostUserMsgHeader;
 use crate::vhost_user::message::{BackendReq, VhostUserMsgValidator, VhostUserU64};
+use crate::vhost_user::Error;
+use std::os::fd::RawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::{io, mem};
+use vm_memory::ByteValued;
 
 struct BackendInternal {
     sock: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>,
@@ -39,7 +39,10 @@ impl BackendInternal {
         self.wait_for_ack(&hdr)
     }
 
-    fn wait_for_ack<V: ByteValued + Sized  + Default + VhostUserMsgValidator>(&mut self, hdr: &VhostUserGpuMsgHeader<GpuBackendReq>) -> vhost_user::Result<V> {
+    fn wait_for_ack<V: ByteValued + Sized + Default + VhostUserMsgValidator>(
+        &mut self,
+        hdr: &VhostUserGpuMsgHeader<GpuBackendReq>,
+    ) -> vhost_user::Result<V> {
         self.check_state()?;
         let (reply, body, rfds) = self.sock.recv_body::<V>()?;
         if !reply.is_reply_for(hdr) || rfds.is_some() || !body.is_valid() {
@@ -56,7 +59,7 @@ pub struct GpuBackend {
 }
 
 impl GpuBackend {
-    fn new(ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>> ) -> Self {
+    fn new(ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>) -> Self {
         Self {
             node: Arc::new(Mutex::new(BackendInternal {
                 sock: ep,
@@ -82,9 +85,7 @@ impl GpuBackend {
 
     /// Create a new instance from a `UnixStream` object.
     pub fn from_stream(sock: UnixStream) -> Self {
-        Self::new(Endpoint::<VhostUserGpuMsgHeader<GpuBackendReq>>::from_stream(
-            sock,
-        ))
+        Self::new(Endpoint::<VhostUserGpuMsgHeader<GpuBackendReq>>::from_stream(sock))
     }
 
     /// Mark endpoint as failed with specified error code.

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -13,7 +13,7 @@ use vm_memory::ByteValued;
 enum_value! {
     /// Type of requests sending from gpu backends to gpu frontends.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-    #[allow(non_camel_case_types)]
+    #[allow(non_camel_case_types, upper_case_acronyms)]
     pub enum GpuBackendReq: u32 {
         /// Get the supported protocol features bitmask.
         GET_PROTOCOL_FEATURES = 1,
@@ -49,7 +49,7 @@ enum_value! {
     }
 }
 
-impl Req for BackendReq {}
+impl Req for GpuBackendReq {}
 
 // Bit mask for common message flags.
 bitflags! {
@@ -97,11 +97,9 @@ impl<R: Req> PartialEq for VhostUserGpuMsgHeader<R> {
 impl<R: Req> VhostUserGpuMsgHeader<R> {
     /// Create a new instance of `VhostUserMsgHeader`.
     pub fn new(request: R, flags: u32, size: u32) -> Self {
-        // Default to protocol version 1
-        let fl = (flags & VhostUserGpuHeaderFlag::ALL_FLAGS.bits()) | 0x1;
         VhostUserGpuMsgHeader {
             request: request.into(),
-            flags: fl,
+            flags: flags, // TODO: maybe check if the flags are valid?
             size,
             _r: PhantomData,
         }
@@ -124,11 +122,6 @@ impl<R: Req> VhostUserGpuMsgHeader<R> {
         } else {
             self.flags &= !VhostUserGpuHeaderFlag::REPLY.bits();
         }
-    }
-
-    /// Check whether reply for this message is requested.
-    pub fn is_need_reply(&self) -> bool {
-        (self.flags & VhostUserGpuHeaderFlag::NEED_REPLY.bits()) != 0
     }
 
     /// Check whether it's the reply message for the request `req`.

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -1,0 +1,177 @@
+//! Implementation parts of the protocol on the socket from VHOST_USER_SET_GPU_SOCKET
+//! see: https://www.qemu.org/docs/master/interop/vhost-user-gpu.html
+
+use crate::vhost_user::header::MsgHeader;
+use crate::vhost_user::message::{
+    enum_value, BackendReq, Req, VhostUserMsgValidator, MAX_MSG_SIZE,
+};
+use crate::vhost_user::Error;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use vm_memory::ByteValued;
+
+enum_value! {
+    /// Type of requests sending from gpu backends to gpu frontends.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[allow(non_camel_case_types)]
+    pub enum GpuBackendReq: u32 {
+        /// Get the supported protocol features bitmask.
+        GET_PROTOCOL_FEATURES = 1,
+        /// Enable protocol features using a bitmask.
+        SET_PROTOCOL_FEATURES,
+        /// Get the preferred display configuration.
+        GET_DISPLAY_INFO,
+        /// Set/show the cursor position.
+        CURSOR_POS,
+        /// Set/hide the cursor.
+        CURSOR_POS_HIDE,
+        /// Set the scanout resolution.
+        /// To disable a scanout, the dimensions width/height are set to 0.
+        SCANOUT,
+        /// Update the scanout content. The data payload contains the graphical bits.
+        /// The display should be flushed and presented.
+        UPDATE,
+        /// Set the scanout resolution/configuration, and share a DMABUF file descriptor for the scanout content,
+        /// which is passed as ancillary data.
+        /// To disable a scanout, the dimensions width/height are set to 0, there is no file descriptor passed.
+        DMABUF_SCANOUT,
+        /// The display should be flushed and presented according to updated region from VhostUserGpuUpdate.
+        // Note: there is no data payload, since the scanout is shared thanks to DMABUF,
+        // that must have been set previously with VHOST_USER_GPU_DMABUF_SCANOUT.
+        DMABUF_UPDATE,
+        /// Retrieve the EDID data for a given scanout.
+        /// This message requires the VHOST_USER_GPU_PROTOCOL_F_EDID protocol feature to be supported.
+        GET_EDID,
+        /// Same as VHOST_USER_GPU_DMABUF_SCANOUT, but also sends the dmabuf modifiers appended to the message,
+        /// which were not provided in the other message.
+        /// This message requires the VHOST_USER_GPU_PROTOCOL_F_DMABUF2 protocol feature to be supported.
+        VHOST_USER_GPU_DMABUF_SCANOUT2,
+    }
+}
+
+impl Req for BackendReq {}
+
+// Bit mask for common message flags.
+bitflags! {
+    /// Common message flags for vhost-user requests and replies.
+    pub struct VhostUserGpuHeaderFlag: u32 {
+        /// Mark message as reply.
+        const REPLY = 0x4;
+    }
+}
+
+/// A vhost-user message consists of 3 header fields and an optional payload. All numbers are in the
+/// machine native byte order.
+#[repr(C, packed)]
+#[derive(Copy)]
+pub struct VhostUserGpuMsgHeader<R: Req> {
+    request: u32,
+    flags: u32,
+    size: u32,
+    _r: PhantomData<R>,
+}
+
+impl<R: Req> Debug for VhostUserGpuMsgHeader<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VhostUserMsgHeader")
+            .field("request", &{ self.request })
+            .field("flags", &{ self.flags })
+            .field("size", &{ self.size })
+            .finish()
+    }
+}
+
+impl<R: Req> Clone for VhostUserGpuMsgHeader<R> {
+    fn clone(&self) -> VhostUserGpuMsgHeader<R> {
+        *self
+    }
+}
+
+impl<R: Req> PartialEq for VhostUserGpuMsgHeader<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.request == other.request && self.flags == other.flags && self.size == other.size
+    }
+}
+
+#[allow(dead_code)]
+impl<R: Req> VhostUserGpuMsgHeader<R> {
+    /// Create a new instance of `VhostUserMsgHeader`.
+    pub fn new(request: R, flags: u32, size: u32) -> Self {
+        // Default to protocol version 1
+        let fl = (flags & VhostUserGpuHeaderFlag::ALL_FLAGS.bits()) | 0x1;
+        VhostUserGpuMsgHeader {
+            request: request.into(),
+            flags: fl,
+            size,
+            _r: PhantomData,
+        }
+    }
+
+    /// Get message type.
+    pub fn get_code(&self) -> crate::vhost_user::Result<R> {
+        R::try_from(self.request).map_err(|_| Error::InvalidMessage)
+    }
+
+    /// Check whether it's a reply message.
+    pub fn is_reply(&self) -> bool {
+        (self.flags & VhostUserGpuHeaderFlag::REPLY.bits()) != 0
+    }
+
+    /// Mark message as reply.
+    pub fn set_reply(&mut self, is_reply: bool) {
+        if is_reply {
+            self.flags |= VhostUserGpuHeaderFlag::REPLY.bits();
+        } else {
+            self.flags &= !VhostUserGpuHeaderFlag::REPLY.bits();
+        }
+    }
+
+    /// Check whether reply for this message is requested.
+    pub fn is_need_reply(&self) -> bool {
+        (self.flags & VhostUserGpuHeaderFlag::NEED_REPLY.bits()) != 0
+    }
+
+    /// Check whether it's the reply message for the request `req`.
+    pub fn is_reply_for(&self, req: &VhostUserGpuMsgHeader<R>) -> bool {
+        if let (Ok(code1), Ok(code2)) = (self.get_code(), req.get_code()) {
+            self.is_reply() && !req.is_reply() && code1 == code2
+        } else {
+            false
+        }
+    }
+
+    /// Get message size.
+    pub fn get_size(&self) -> u32 {
+        self.size
+    }
+
+    /// Set message size.
+    pub fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+impl<R: Req> Default for VhostUserGpuMsgHeader<R> {
+    fn default() -> Self {
+        VhostUserGpuMsgHeader {
+            request: 0,
+            flags: 0x1,
+            size: 0,
+            _r: PhantomData,
+        }
+    }
+}
+
+// SAFETY: Safe because all fields of VhostUserMsgHeader are POD.
+unsafe impl<R: Req> ByteValued for VhostUserGpuMsgHeader<R> {}
+
+impl<T: Req> VhostUserMsgValidator for VhostUserGpuMsgHeader<T> {
+    #[allow(clippy::if_same_then_else)]
+    fn is_valid(&self) -> bool {
+        self.get_code().is_ok()
+    }
+}
+
+impl<R: Req> MsgHeader for VhostUserGpuMsgHeader<R> {
+    type Request = R;
+}

--- a/vhost/src/vhost_user/header.rs
+++ b/vhost/src/vhost_user/header.rs
@@ -4,6 +4,10 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use vm_memory::ByteValued;
 
+pub(super) trait MsgHeader: ByteValued + Default + VhostUserMsgValidator {
+    type Request: Req;
+}
+
 /// Common message header for vhost-user requests and replies.
 /// A vhost-user message consists of 3 header fields and an optional payload. All numbers are in the
 /// machine native byte order.
@@ -149,4 +153,8 @@ impl<T: Req> VhostUserMsgValidator for VhostUserMsgHeader<T> {
         }
         true
     }
+}
+
+impl<R: Req> MsgHeader for VhostUserMsgHeader<R> {
+    type Request = R;
 }

--- a/vhost/src/vhost_user/header.rs
+++ b/vhost/src/vhost_user/header.rs
@@ -1,0 +1,152 @@
+use crate::vhost_user::message::{Req, VhostUserHeaderFlag, VhostUserMsgValidator, MAX_MSG_SIZE};
+use crate::vhost_user::Error;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use vm_memory::ByteValued;
+
+/// Common message header for vhost-user requests and replies.
+/// A vhost-user message consists of 3 header fields and an optional payload. All numbers are in the
+/// machine native byte order.
+#[repr(C, packed)]
+#[derive(Copy)]
+pub struct VhostUserMsgHeader<R: Req> {
+    request: u32,
+    flags: u32,
+    size: u32,
+    _r: PhantomData<R>,
+}
+
+impl<R: Req> Debug for VhostUserMsgHeader<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VhostUserMsgHeader")
+            .field("request", &{ self.request })
+            .field("flags", &{ self.flags })
+            .field("size", &{ self.size })
+            .finish()
+    }
+}
+
+impl<R: Req> Clone for VhostUserMsgHeader<R> {
+    fn clone(&self) -> VhostUserMsgHeader<R> {
+        *self
+    }
+}
+
+impl<R: Req> PartialEq for VhostUserMsgHeader<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.request == other.request && self.flags == other.flags && self.size == other.size
+    }
+}
+
+#[allow(dead_code)]
+impl<R: Req> VhostUserMsgHeader<R> {
+    /// Create a new instance of `VhostUserMsgHeader`.
+    pub fn new(request: R, flags: u32, size: u32) -> Self {
+        // Default to protocol version 1
+        let fl = (flags & VhostUserHeaderFlag::ALL_FLAGS.bits()) | 0x1;
+        VhostUserMsgHeader {
+            request: request.into(),
+            flags: fl,
+            size,
+            _r: PhantomData,
+        }
+    }
+
+    /// Get message type.
+    pub fn get_code(&self) -> crate::vhost_user::Result<R> {
+        R::try_from(self.request).map_err(|_| Error::InvalidMessage)
+    }
+
+    /// Set message type.
+    pub fn set_code(&mut self, request: R) {
+        self.request = request.into();
+    }
+
+    /// Get message version number.
+    pub fn get_version(&self) -> u32 {
+        self.flags & 0x3
+    }
+
+    /// Set message version number.
+    pub fn set_version(&mut self, ver: u32) {
+        self.flags &= !0x3;
+        self.flags |= ver & 0x3;
+    }
+
+    /// Check whether it's a reply message.
+    pub fn is_reply(&self) -> bool {
+        (self.flags & VhostUserHeaderFlag::REPLY.bits()) != 0
+    }
+
+    /// Mark message as reply.
+    pub fn set_reply(&mut self, is_reply: bool) {
+        if is_reply {
+            self.flags |= VhostUserHeaderFlag::REPLY.bits();
+        } else {
+            self.flags &= !VhostUserHeaderFlag::REPLY.bits();
+        }
+    }
+
+    /// Check whether reply for this message is requested.
+    pub fn is_need_reply(&self) -> bool {
+        (self.flags & VhostUserHeaderFlag::NEED_REPLY.bits()) != 0
+    }
+
+    /// Mark that reply for this message is needed.
+    pub fn set_need_reply(&mut self, need_reply: bool) {
+        if need_reply {
+            self.flags |= VhostUserHeaderFlag::NEED_REPLY.bits();
+        } else {
+            self.flags &= !VhostUserHeaderFlag::NEED_REPLY.bits();
+        }
+    }
+
+    /// Check whether it's the reply message for the request `req`.
+    pub fn is_reply_for(&self, req: &VhostUserMsgHeader<R>) -> bool {
+        if let (Ok(code1), Ok(code2)) = (self.get_code(), req.get_code()) {
+            self.is_reply() && !req.is_reply() && code1 == code2
+        } else {
+            false
+        }
+    }
+
+    /// Get message size.
+    pub fn get_size(&self) -> u32 {
+        self.size
+    }
+
+    /// Set message size.
+    pub fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+impl<R: Req> Default for VhostUserMsgHeader<R> {
+    fn default() -> Self {
+        VhostUserMsgHeader {
+            request: 0,
+            flags: 0x1,
+            size: 0,
+            _r: PhantomData,
+        }
+    }
+}
+
+// SAFETY: Safe because all fields of VhostUserMsgHeader are POD.
+unsafe impl<R: Req> ByteValued for VhostUserMsgHeader<R> {}
+
+impl<T: Req> VhostUserMsgValidator for VhostUserMsgHeader<T> {
+    #[allow(clippy::if_same_then_else)]
+    fn is_valid(&self) -> bool {
+        if self.get_code().is_err() {
+            return false;
+        } else if self.size as usize > MAX_MSG_SIZE {
+            return false;
+        } else if self.get_version() != 0x1 {
+            return false;
+        } else if (self.flags & VhostUserHeaderFlag::RESERVED_BITS.bits()) != 0 {
+            return false;
+        }
+        true
+    }
+}

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -12,7 +12,6 @@
 use std::fmt::Debug;
 use std::fs::File;
 use std::io;
-use std::marker::PhantomData;
 use std::ops::Deref;
 
 use vm_memory::{mmap::NewBitmap, ByteValued, Error as MmapError, FileOffset, MmapRegion};
@@ -240,152 +239,6 @@ bitflags! {
         const ALL_FLAGS = 0xc;
         /// All reserved bits.
         const RESERVED_BITS = !0xf;
-    }
-}
-
-/// Common message header for vhost-user requests and replies.
-/// A vhost-user message consists of 3 header fields and an optional payload. All numbers are in the
-/// machine native byte order.
-#[repr(C, packed)]
-#[derive(Copy)]
-pub(super) struct VhostUserMsgHeader<R: Req> {
-    request: u32,
-    flags: u32,
-    size: u32,
-    _r: PhantomData<R>,
-}
-
-impl<R: Req> Debug for VhostUserMsgHeader<R> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VhostUserMsgHeader")
-            .field("request", &{ self.request })
-            .field("flags", &{ self.flags })
-            .field("size", &{ self.size })
-            .finish()
-    }
-}
-
-impl<R: Req> Clone for VhostUserMsgHeader<R> {
-    fn clone(&self) -> VhostUserMsgHeader<R> {
-        *self
-    }
-}
-
-impl<R: Req> PartialEq for VhostUserMsgHeader<R> {
-    fn eq(&self, other: &Self) -> bool {
-        self.request == other.request && self.flags == other.flags && self.size == other.size
-    }
-}
-
-impl<R: Req> VhostUserMsgHeader<R> {
-    /// Create a new instance of `VhostUserMsgHeader`.
-    pub fn new(request: R, flags: u32, size: u32) -> Self {
-        // Default to protocol version 1
-        let fl = (flags & VhostUserHeaderFlag::ALL_FLAGS.bits()) | 0x1;
-        VhostUserMsgHeader {
-            request: request.into(),
-            flags: fl,
-            size,
-            _r: PhantomData,
-        }
-    }
-
-    /// Get message type.
-    pub fn get_code(&self) -> Result<R> {
-        R::try_from(self.request).map_err(|_| Error::InvalidMessage)
-    }
-
-    /// Set message type.
-    pub fn set_code(&mut self, request: R) {
-        self.request = request.into();
-    }
-
-    /// Get message version number.
-    pub fn get_version(&self) -> u32 {
-        self.flags & 0x3
-    }
-
-    /// Set message version number.
-    pub fn set_version(&mut self, ver: u32) {
-        self.flags &= !0x3;
-        self.flags |= ver & 0x3;
-    }
-
-    /// Check whether it's a reply message.
-    pub fn is_reply(&self) -> bool {
-        (self.flags & VhostUserHeaderFlag::REPLY.bits()) != 0
-    }
-
-    /// Mark message as reply.
-    pub fn set_reply(&mut self, is_reply: bool) {
-        if is_reply {
-            self.flags |= VhostUserHeaderFlag::REPLY.bits();
-        } else {
-            self.flags &= !VhostUserHeaderFlag::REPLY.bits();
-        }
-    }
-
-    /// Check whether reply for this message is requested.
-    pub fn is_need_reply(&self) -> bool {
-        (self.flags & VhostUserHeaderFlag::NEED_REPLY.bits()) != 0
-    }
-
-    /// Mark that reply for this message is needed.
-    pub fn set_need_reply(&mut self, need_reply: bool) {
-        if need_reply {
-            self.flags |= VhostUserHeaderFlag::NEED_REPLY.bits();
-        } else {
-            self.flags &= !VhostUserHeaderFlag::NEED_REPLY.bits();
-        }
-    }
-
-    /// Check whether it's the reply message for the request `req`.
-    pub fn is_reply_for(&self, req: &VhostUserMsgHeader<R>) -> bool {
-        if let (Ok(code1), Ok(code2)) = (self.get_code(), req.get_code()) {
-            self.is_reply() && !req.is_reply() && code1 == code2
-        } else {
-            false
-        }
-    }
-
-    /// Get message size.
-    pub fn get_size(&self) -> u32 {
-        self.size
-    }
-
-    /// Set message size.
-    pub fn set_size(&mut self, size: u32) {
-        self.size = size;
-    }
-}
-
-impl<R: Req> Default for VhostUserMsgHeader<R> {
-    fn default() -> Self {
-        VhostUserMsgHeader {
-            request: 0,
-            flags: 0x1,
-            size: 0,
-            _r: PhantomData,
-        }
-    }
-}
-
-// SAFETY: Safe because all fields of VhostUserMsgHeader are POD.
-unsafe impl<R: Req> ByteValued for VhostUserMsgHeader<R> {}
-
-impl<T: Req> VhostUserMsgValidator for VhostUserMsgHeader<T> {
-    #[allow(clippy::if_same_then_else)]
-    fn is_valid(&self) -> bool {
-        if self.get_code().is_err() {
-            return false;
-        } else if self.size as usize > MAX_MSG_SIZE {
-            return false;
-        } else if self.get_version() != 0x1 {
-            return false;
-        } else if (self.flags & VhostUserHeaderFlag::RESERVED_BITS.bits()) != 0 {
-            return false;
-        }
-        true
     }
 }
 
@@ -1161,6 +1014,7 @@ impl QueueRegionPacked {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vhost_user::header::VhostUserMsgHeader;
     use std::mem;
 
     #[cfg(feature = "xen")]

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -87,6 +87,7 @@ macro_rules! enum_value {
         }
     }
 }
+pub(crate) use enum_value;
 
 enum_value! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -54,9 +54,9 @@ mod backend_req;
 #[cfg(feature = "vhost-user-backend")]
 pub use self::backend_req::Backend;
 #[cfg(feature = "vhost-user-gpu-set-socket")]
-mod gpu_message;
-#[cfg(feature = "vhost-user-gpu-set-socket")]
 mod gpu_backend_req;
+#[cfg(feature = "vhost-user-gpu-set-socket")]
+mod gpu_message;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -21,6 +21,7 @@
 use std::fs::File;
 use std::io::Error as IOError;
 
+mod header;
 pub mod message;
 pub use self::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -55,6 +55,8 @@ mod backend_req;
 pub use self::backend_req::Backend;
 #[cfg(feature = "vhost-user-gpu-set-socket")]
 mod gpu_message;
+#[cfg(feature = "vhost-user-gpu-set-socket")]
+mod gpu_backend_req;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -53,6 +53,8 @@ pub use self::backend_req_handler::{
 mod backend_req;
 #[cfg(feature = "vhost-user-backend")]
 pub use self::backend_req::Backend;
+#[cfg(feature = "vhost-user-gpu-set-socket")]
+mod gpu_message;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]


### PR DESCRIPTION
@dorindabassey

Todo list:

- The `set_gpu_socket` trait method currently takes a UnixStream as an argument, it should take a `GpuBackend`. The `GpuBackend` should work, but I haven't tested it yet. (The `GpuBackend` should be constructible from the `UnixStream`).
- The structs needed as replies for the `GpuBackend::send_message` are not defined yet. (There are probably identical to the ones in the virtio spec - so they are defined in our vhost-user-gpu so just copy them over. (Probably put them in the `gpu_message.rs` file).
- Define methods such as `GpuBackend::get_display_info` that calls `GpuBackend::send_message` with `GpuBackendReq::GET_DISPLAY_INFO` and correct `V` generic parameter (previous bullet point) (`V` is the struct that represent the reply format)
   - (this needs to be done for each item of `GpuBackendReq` enum)  
- Attempt to call  `GpuBackend::get_display_info` in our `vhost-user-gpu`.
- Some cleanup:
    - I think there could be 3 files for the messages: `gpu_message.rs`, `generic_message.rs` (maybe also come up with a better name) and `vhost_message.rs`  Basically put the trait definitions in the `generic_message.rs` and normal vhost messages in the `vhost_message.rs`. This would also mean undoing the commit "Move VhostUserMsgHeader to a separate file"